### PR TITLE
Refactor to allow for multiple food ordre channels

### DIFF
--- a/foodbot.py
+++ b/foodbot.py
@@ -10,39 +10,41 @@ load_dotenv()
 TOKEN = os.getenv('DISCORD_BOT_TOKEN')
 
 intents = disnake.Intents.default()
-intents.message_content = True  # Enable message content intent
-intents.members = True  # Enable members intent
+intents.message_content = True
+intents.members = True
 
 bot = commands.Bot(command_prefix='!', intents=intents)
-current_order = None
-allowed_channel_name = "food-order"
-allowed_channel_name = "food-order"
-order_message = None
-last_order_backup = None  # Backup variable for the last order
+
+# Support multiple channels
+orders = {}  # {channel_id: current_order}
+order_messages = {}  # {channel_id: order_message}
+last_order_backups = {}  # {channel_id: last_order_backup}
+final_order_messages = {}  # {channel_id: final_order_message}
 
 @bot.event
 async def on_ready():
     print(f'Logged in as {bot.user}')
     print("Bot is ready.")
-    channel = disnake.utils.get(bot.get_all_channels(), name=allowed_channel_name)
-    if channel:
-        print(f"Channel '{allowed_channel_name}' found.")
-        await clear_and_initialize_channel(channel)
-    else:
-        print(f"Channel '{allowed_channel_name}' not found.")
+    for channel in bot.get_all_channels():
+        if channel.name.startswith("food-order"):
+            print(f"Channel '{channel.name}' found.")
+            await clear_and_initialize_channel(channel)
 
 def is_allowed_channel(interaction):
-    return interaction.channel.name == allowed_channel_name
+    return interaction.channel.name.startswith("food-order")
 
 async def clear_and_initialize_channel(channel):
-    global order_message
+    channel_id = channel.id
     async for message in channel.history(limit=100):
         await message.delete()
-    order_message = await channel.send("No active order.")
+    order_messages[channel_id] = await channel.send("No active order.")
 
 @bot.event
 async def on_message(message):
-    if isinstance(message.channel, disnake.TextChannel) and message.channel.name == allowed_channel_name and current_order is not None:
+    channel_id = message.channel.id
+    if (isinstance(message.channel, disnake.TextChannel)
+        and message.channel.name.startswith("food-order")
+        and channel_id in orders):
         if message.author == bot.user:
             return
         await message.delete()
@@ -50,89 +52,96 @@ async def on_message(message):
 @bot.slash_command(name="startorder", description="Start a new food order")
 async def start_order(interaction: disnake.ApplicationCommandInteraction, place: str, time: str):
     if not is_allowed_channel(interaction):
-        await interaction.response.send_message(f'This command can only be used in the #{allowed_channel_name} channel.', ephemeral=True)
+        await interaction.response.send_message("This command can only be used in a food-order channel.", ephemeral=True)
         return
 
-    global current_order
-    global order_message  
+    channel_id = interaction.channel.id
 
-    if current_order is not None:
-        await interaction.user.send('An order is already in progress.')
-        await interaction.response.send_message('An order is already in progress.', ephemeral=True)
+    if channel_id in orders:
+        await interaction.user.send("An order is already in progress.")
+        await interaction.response.send_message("An order is already in progress.", ephemeral=True)
         return
 
-    channel = interaction.channel
-    async for message in channel.history(limit=100):
-        if message != order_message:
+    async for message in interaction.channel.history(limit=100):
+        if channel_id in order_messages and message.id != order_messages[channel_id].id:
             await message.delete()
 
     cet_tz = pytz.timezone("Europe/Copenhagen")
-    start_time = datetime.now(pytz.utc).astimezone(cet_tz).strftime("%Y-%m-%d %H:%M:%S")  # Get current time
+    start_time = datetime.now(pytz.utc).astimezone(cet_tz).strftime("%Y-%m-%d %H:%M:%S")
 
-    current_order = {
-        'starter': interaction.user.id, 
-        'username': interaction.user.name, 
-        'place': place, 
-        'time': time, 
-        'start_time': start_time,  # Store start time
+    orders[channel_id] = {
+        'starter': interaction.user.id,
+        'username': interaction.user.name,
+        'place': place,
+        'time': time,
+        'start_time': start_time,
         'items': {}
     }
 
-    await update_order_message(interaction)
-    await interaction.response.send_message('Order started!', ephemeral=True)
+    await update_order_message(interaction, force_new=True)
+    await interaction.response.send_message("Order started!", ephemeral=True)
 
-async def update_order_message(interaction):
-    global order_message
-    channel = interaction.channel
-    if current_order is None:
+async def update_order_message(interaction, force_new=False):
+    channel_id = interaction.channel.id
+
+    if force_new and channel_id in order_messages:
+        try:
+            await order_messages[channel_id].delete()
+        except disnake.NotFound:
+            pass
+        order_messages[channel_id] = None
+
+    order = orders.get(channel_id)
+    if not order:
         content = "No active order."
     else:
-        order_list = [f'{interaction.guild.get_member(user_id).mention}: {", ".join(user_orders)}' for user_id, user_orders in current_order['items'].items()]
-        content = (f'Order in progress by {current_order["username"]}\n \n'
-                   f'From: {current_order["place"]} \nOrder before: {current_order["time"]}\n'
-                   f'Started at: {current_order["start_time"]} \n \n'  # Add start time to the message
-                   'Use "/addorder [order]" to order your food.\n' f'Current orders: \n' + '\n'.join(order_list))
-    
-    if order_message is None:
-        order_message = await channel.send(content)
-    else:
-        await order_message.edit(content=content)
+        order_list = [
+            f'{interaction.guild.get_member(uid).mention}: {", ".join(items)}'
+            for uid, items in order['items'].items()
+        ]
+        content = (f'Order in progress by {order["username"]}\n\n'
+                   f'From: {order["place"]} \nOrder before: {order["time"]}\n'
+                   f'Started at: {order["start_time"]}\n\n'
+                   'Use "/addorder [order]" to order your food.\n' +
+                   ('Current orders:\n' + '\n'.join(order_list) if order_list else "No orders yet."))
 
-@bot.slash_command(name="addorder", description="Add an item to the current order (will overwrite any previous order)")
+    if channel_id not in order_messages or order_messages[channel_id] is None:
+        order_messages[channel_id] = await interaction.channel.send(content)
+    else:
+        await order_messages[channel_id].edit(content=content)
+
+@bot.slash_command(name="addorder", description="Add an item to the current order (overwrites previous)")
 async def add_order(interaction: disnake.ApplicationCommandInteraction, order: str):
     if not is_allowed_channel(interaction):
-        await interaction.response.send_message(f'This command can only be used in the #{allowed_channel_name} channel.', ephemeral=True)
+        await interaction.response.send_message("This command can only be used in a food-order channel.", ephemeral=True)
         return
 
-    global current_order
-    if current_order is None:
-        await interaction.user.send('No active order. Start an order using /startorder.')
-        await interaction.response.send_message('No active order. Start an order using /startorder.', ephemeral=True)
+    channel_id = interaction.channel.id
+    current_order = orders.get(channel_id)
+    if not current_order:
+        await interaction.user.send("No active order. Start an order using /startorder.")
+        await interaction.response.send_message("No active order.", ephemeral=True)
         return
 
     current_order['items'][interaction.user.id] = [order]
-    
     await update_order_message(interaction)
-    await interaction.response.send_message('Your order has been updated!', ephemeral=True)
-
-final_order_message = None  # Variable to store the finalized order message
+    await interaction.response.send_message("Your order has been updated!", ephemeral=True)
 
 @bot.slash_command(name="endorder", description="Finalize the current order")
 async def finalize_order(interaction: disnake.ApplicationCommandInteraction, mobilepay: str = None):
     if not is_allowed_channel(interaction):
-        await interaction.response.send_message(f'This command can only be used in the #{allowed_channel_name} channel.', ephemeral=True)
+        await interaction.response.send_message("This command can only be used in a food-order channel.", ephemeral=True)
         return
-    
-    global current_order, last_order_backup, final_order_message
-    if current_order is None:
-        await interaction.user.send('No active order to finalize.')
-        await interaction.response.send_message('No active order to finalize.', ephemeral=True)
-        return
-    
-    # Backup the current order before finalizing
-    last_order_backup = current_order.copy()
 
-    # Prepare the final order list message with mentions
+    channel_id = interaction.channel.id
+    current_order = orders.get(channel_id)
+    if not current_order:
+        await interaction.user.send("No active order to finalize.")
+        await interaction.response.send_message("No active order to finalize.", ephemeral=True)
+        return
+
+    last_order_backups[channel_id] = current_order.copy()
+
     order_list = []
     for user_id, user_orders in current_order['items'].items():
         member = interaction.guild.get_member(user_id)
@@ -140,92 +149,81 @@ async def finalize_order(interaction: disnake.ApplicationCommandInteraction, mob
             order_list.append(f'{member.mention}: {", ".join(user_orders)}')
         else:
             order_list.append(f'Unknown User ({user_id}): {", ".join(user_orders)}')
-    
-    # Construct the final message
+
     order_list_message = "The following order has been ended:\n" + '\n'.join(order_list)
-    
-    # Add MobilePay details if provided
     if mobilepay:
-        order_list_message += f"\n\nPlease MobilePay to following number: {mobilepay}"
+        order_list_message += f"\n\nPlease MobilePay to the following number: {mobilepay}"
 
-    # Send the final order list to the channel and save the message reference
-    final_order_message = await interaction.channel.send(order_list_message)
-    
-    # Send the finalized order as a DM to the user ending the order
-    await interaction.user.send("Order finalized:\n" + order_list_message)
+    final_order_messages[channel_id] = await interaction.channel.send(order_list_message)
+    await interaction.user.send(
+    f"Order finalized for **{current_order['place']}**:\n\n"
+    f"{order_list_message}\n\n"
+    "If you ended it by mistake, you can use `/restoreorder` to restore the last order."
+)
 
-    # Clear the current order
-    current_order = None
+
+    del orders[channel_id]
     await update_order_message(interaction)
-    await interaction.response.send_message('Order finalized!', ephemeral=True)
+    await interaction.response.send_message("Order finalized!", ephemeral=True)
 
-
-@bot.slash_command(name="restoreorder", description="Restore the last ended order if it was ended by mistake")
+@bot.slash_command(name="restoreorder", description="Restore the last ended order")
 async def restore_order(interaction: disnake.ApplicationCommandInteraction):
     if not is_allowed_channel(interaction):
-        await interaction.response.send_message(f'This command can only be used in the #{allowed_channel_name} channel.', ephemeral=True)
+        await interaction.response.send_message("This command can only be used in a food-order channel.", ephemeral=True)
         return
-    
-    global current_order, last_order_backup, final_order_message
-    if current_order is not None:
-        await interaction.response.send_message("An order is already in progress, cannot restore another order.", ephemeral=True)
+
+    channel_id = interaction.channel.id
+    if channel_id in orders:
+        await interaction.response.send_message("An order is already in progress.", ephemeral=True)
         return
-    
-    if last_order_backup is None:
+
+    if channel_id not in last_order_backups:
         await interaction.response.send_message("No order available to restore.", ephemeral=True)
         return
 
-    # Remove the finalized order message if it exists
-    if final_order_message:
-        await final_order_message.delete()
-        final_order_message = None  # Reset the reference
+    if final_order_messages.get(channel_id):
+        await final_order_messages[channel_id].delete()
+        final_order_messages[channel_id] = None
 
-    # Restore the last backup
-    current_order = last_order_backup
+    orders[channel_id] = last_order_backups[channel_id]
     await update_order_message(interaction)
     await interaction.response.send_message("The previous order has been restored.", ephemeral=True)
 
 @bot.slash_command(name="clearorder", description="Remove your order from the current order")
 async def clear_order(interaction: disnake.ApplicationCommandInteraction):
-    print("clear_order command defined")
     if not is_allowed_channel(interaction):
-        await interaction.response.send_message(f'This command can only be used in the #{allowed_channel_name} channel.', ephemeral=True)
+        await interaction.response.send_message("This command can only be used in a food-order channel.", ephemeral=True)
         return
-    
-    global current_order
-    if current_order is None:
-        await interaction.user.send('No active order to modify.')
-        await interaction.response.send_message('No active order to modify.', ephemeral=True)
+
+    channel_id = interaction.channel.id
+    current_order = orders.get(channel_id)
+    if not current_order:
+        await interaction.user.send("No active order to modify.")
+        await interaction.response.send_message("No active order to modify.", ephemeral=True)
         return
-    
+
     if interaction.user.id not in current_order['items']:
-        await interaction.user.send('You have no items in the current order.')
-        await interaction.response.send_message('You have no items in the current order.', ephemeral=True)
+        await interaction.user.send("You have no items in the current order.")
+        await interaction.response.send_message("You have no items in the current order.", ephemeral=True)
         return
-    
+
     del current_order['items'][interaction.user.id]
     await update_order_message(interaction)
-    
-    await interaction.response.send_message('Your order has been removed!', ephemeral=True)
-    print("clear_order command processed")
+    await interaction.response.send_message("Your order has been removed!", ephemeral=True)
 
 @bot.slash_command(name="help", description="Shows a list of available commands")
 async def help_command(interaction: disnake.ApplicationCommandInteraction):
-    print("help command defined")
     help_text = (
         "Hello\n"
-        "My name is FoodBot, i help you organize a food order, to use me see my commands below:\n \n"
-        "/startorder [place] [time] - Starts a new food order\n \n"
-        "/addorder [order] - Add an item to the current order\n \n"
-        "/endorder - Finalize the current order\n \n"
-        "/clearorder - Remove your order from the current order\n \n"
-        "/Restoreorder - Restores the last ended order, if it was ended by mistake\n \n"
-        "/help - Show this help message\n \n"
+        "My name is FoodBot, I help you organize a food order.\n\n"
+        "/startorder [place] [time] - Starts a new food order\n"
+        "/addorder [order] - Add an item to the current order\n"
+        "/endorder - Finalize the current order\n"
+        "/clearorder - Remove your order from the current order\n"
+        "/restoreorder - Restore the last ended order if ended by mistake\n"
+        "/help - Show this help message"
     )
-    # Use ephemeral response for the help message to avoid confusion
-    await interaction.response.send_message('A list of commands has been sent to your DMs!', ephemeral=True)
-    await interaction.user.send(help_text)  # Send the help text to the user's DM
-    print("help command processed")
-
+    await interaction.response.send_message("A list of commands has been sent to your DMs!", ephemeral=True)
+    await interaction.user.send(help_text)
 
 bot.run(TOKEN)


### PR DESCRIPTION
On the boot of the bot, it finds all channels starting with food-order such as food-order, food-order-1, food-order-2 and so on.
and runs them in parallel allowing multiple orders to be run at the same time. 

also changed /startorder to create a new message instead of editing its old message. this makes discord send a notification when an order is started. 